### PR TITLE
Modernize mobile nav APIs, refresh docs, add dev tooling config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "enabledPlugins": {
+    "modern-web-guidance@googlechrome": true
+  },
+  "extraKnownMarketplaces": {
+    "googlechrome": {
+      "source": {
+        "source": "github",
+        "repo": "GoogleChrome/modern-web-guidance"
+      }
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+	"mcpServers": {
+		"playwright": {
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "@playwright/mcp@latest"],
+			"env": {}
+		}
+	}
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,224 +1,82 @@
-# Claude Code Instructions
+# CLAUDE.md
 
-This file contains instructions to help Claude Code work more efficiently with the pob.dev codebase.
+pob.dev is a statically generated personal blog: Eleventy (templates/content) + Lit (SSR web components) + PageFind (client-side search), deployed to Cloudflare Workers. Node.js 22+ required. Exact dependency versions live in `package.json` — do not trust version numbers written in prose anywhere.
 
-## Project Overview
+## Rules
 
-pob.dev is a statically-generated personal website and blog built with:
-- **Eleventy 3.1.2** (static site generator)
-- **Lit 3.3.1** (web components with SSR)
-- **PageFind 1.3.0** (client-side search)
-- **Cloudflare Workers** (hosting platform)
+1. Read a file before editing it. Follow the patterns already in the file you are changing.
+2. Indent with tabs (width 2). Always use braces, even for single-line `if` statements. Prettier enforces formatting — run `npm run format` after editing and `npm run lint` before committing.
+3. Never edit anything in `public/` — it is generated build output and git-ignored.
+4. Pushing to `main` deploys to production via GitHub Actions, so verify changes before committing.
+5. Use commit prefixes: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`.
+6. When you change or add a custom plugin in `11ty/`, update or add its unit test in `tests/unit/`.
+7. Do not add bundlers, frameworks, or new runtime dependencies without being asked. This site deliberately uses plain web platform features (ES modules, import maps, CSS layers).
 
-## Essential Documentation
-
-Before making changes or answering questions about the project, refer to these docs:
-
-- [docs/architecture.md](docs/architecture.md) - Technical architecture, tech stack, data flow, and key features
-- [docs/development.md](docs/development.md) - Development setup, available scripts, project structure, and content creation
-- [docs/deployment.md](docs/deployment.md) - CI/CD pipeline, deployment methods, and troubleshooting
-- [docs/maintenance.md](docs/maintenance.md) - Maintenance tasks, dependency management, and common issues
-
-## Quick Reference
-
-### Key Directories
-
-- `src/` - All source content and templates
-  - `src/blog/YYYY/MM/` - Blog posts organized by date
-  - `src/_includes/` - Layouts and components
-  - `src/assets/` - CSS, JS, fonts
-  - `src/_data/` - Global data files
-- `11ty/` - Custom Eleventy plugins
-- `public/` - Build output (git-ignored)
-- `docs/` - Project documentation
-
-### Common Commands
+## Commands
 
 ```bash
-npm start              # Development server with hot reload (localhost:8080)
-npm run build          # Full production build (Eleventy + PageFind)
-npm run build:11ty     # Build static site only (faster for testing)
-npm run build:index    # Generate PageFind search index only
-npm run lint           # Check code formatting
-npm run format         # Auto-format all source files
-npm run clean          # Remove build artifacts
-npm run dev            # Local Cloudflare Workers environment (localhost:8787)
-npm run deploy         # Deploy to Cloudflare Workers
+npm start              # Dev server, hot reload, drafts visible (localhost:8080)
+npm run build          # Production build: Eleventy then PageFind index → public/
+npm run build:11ty     # Eleventy only (faster; skips search index)
+npm run build:index    # PageFind search index only (requires prior build:11ty)
+npm run test:unit      # Node test runner unit tests (tests/unit/)
+npm test               # Playwright e2e tests (tests/e2e/; starts dev server itself)
+npm run lint           # Prettier check
+npm run format         # Prettier write
+npm run clean          # Delete build artifacts (keeps .env)
+npm run dev            # Serve public/ via local Cloudflare Workers (localhost:8787; run build first)
+npm run deploy         # Manual deploy to Cloudflare (CI normally does this)
 ```
 
-### Project Conventions
+## Verify your changes
 
-**Blog Posts:**
-- Location: `src/blog/YYYY/MM/post-name.md`
-- Requires frontmatter: `title`, `description`, `date`
-- Optional: `tags`, `draft: true`, `updatedDate`
-- Drafts visible in dev, hidden in production
-- Use `updatedDate` when updating a post (displays as "(Updated ...)")
+- Minimum for any code change: `npm run lint` and `npm run test:unit`.
+- For template/content/CSS changes, also view the result with `npm start`.
+- Before claiming a change complete: `npm run build` succeeds, and `npm test` passes if page structure or behavior changed. If content changed, confirm search works after a full `npm run build`.
+- Check both light and dark mode (dark mode follows `prefers-color-scheme`; there is no toggle) and mobile/desktop widths.
+- When using Playwright MCP to drive the site manually, save any screenshots into `.playwright-mcp/` (already git-ignored) rather than the repo root.
 
-**CSS:**
-- Layer order: `reset, config, base, utility, layout`
-- Use CSS custom properties in `src/assets/css/partials/_vars.css`
-- Dark mode via `prefers-color-scheme`
-- BEM-like naming for components
-- Breakpoints (mobile-first):
-  - `768px` - tablet (2 columns, 18px font)
-  - `1024px` - desktop (3 columns)
-- Use modern media query syntax: `@media (width >= 768px)`
+## Where things live
 
-**Web Components:**
-- Located in `src/assets/js/components/`
-- Built with Lit
-- Server-side rendered at build time
-- Examples: `<pob-app>`, `<pob-note>`, `<pob-demo>`
+| Path | Contents |
+|------|----------|
+| `src/blog/YYYY/MM/*.md` | Blog posts |
+| `src/_includes/` | Nunjucks layouts and partials |
+| `src/_data/` | Global data (author, metadata) |
+| `src/assets/css/` | Stylesheets (`global.css` + `partials/` + `components/`) |
+| `src/assets/js/components/` | Lit components: `app.js`, `demo.js`, `note.js`, `tile.js` |
+| `11ty/` | Custom Eleventy plugins (drafts, feeds, TOC, syntax highlighting, externals) |
+| `tests/unit/`, `tests/e2e/` | Node unit tests for plugins; Playwright browser tests |
+| `eleventy.config.js` | Main Eleventy configuration |
+| `feeds.json` | External RSS feeds for the Reading page |
+| `.github/workflows/ci.yml` | CI/CD: build + unit tests + e2e tests, then deploy on `main` |
+| `docs/` | Detailed documentation (see below) |
 
-**Live Code Demos:**
-- Use ` ```html live ` to create interactive HTML demos
-- Renders code block with a "Run" button
-- Clicking "Run" shows the output in a sandboxed iframe
-- Supports inline CSS and JavaScript
+## Conventions
 
-**External Feeds:**
-- Configure in `feeds.json`
-- Date filtering uses ISO 8601 durations (e.g., `P90D` for 90 days)
-- Automatically watched in development mode
+**Blog posts** — file at `src/blog/YYYY/MM/post-name.md`. Frontmatter requires `title`, `description`, `date`. Optional: `tags` (list), `draft: true` (visible in dev only, excluded from production and feeds), `updatedDate` (add when significantly revising a published post). TOC is auto-generated from headings; external links auto-open in new tabs.
 
-### Code Style
+**Markdown extras** — note boxes via `> [!note]` / `[!info]` / `[!success]` / `[!warning]` / `[!error]` (rendered as `<pob-note>`); footnotes; ` ```html live ` makes an HTML code block runnable in a sandboxed iframe.
 
-- **Indentation:** Tabs (size 2)
-- **Line width:** 120 characters (200 for Markdown/SCSS)
-- **Braces:** Always required, even for single-line statements
-- **Formatting:** Enforced via Prettier
-- Always run `npm run lint` before committing
+**CSS** — layer order is `reset, config, base, utility, interactions, layout` (see `src/assets/css/global.css`). Design tokens are `@property` custom properties in `partials/_vars.css`; dark mode overrides them under `@media (prefers-color-scheme: dark)`. BEM-like class names. Mobile-first with modern range syntax: `@media (width >= 768px)` (tablet), `@media (width >= 1024px)` (desktop).
 
-```javascript
-// ✅ Good - always use braces
-if (condition) {
-	return null;
-}
+**Web components** — Lit, server-side rendered at build time by `@lit-labs/eleventy-plugin-lit`; keep them progressive-enhancement only. Add new components in `src/assets/js/components/` and follow `note.js` as the template.
 
-// ❌ Bad - no braces
-if (condition) return null;
-```
+## When things break
 
-## Working with Claude Code
+| Symptom | Fix |
+|---------|-----|
+| Build failing | `npm run clean` then `npm run build` |
+| Search empty/broken | Full `npm run build` (index requires built HTML) |
+| Drafts not showing | Drafts only appear under `npm start`, never in builds |
+| CSS not applying | Check layer order and that the file is imported in `global.css` |
+| Hot reload broken | Free port 8080, restart `npm start` |
 
-### Before Making Changes
+## Detailed docs
 
-1. **Read relevant files first** - Always use the Read tool before suggesting modifications
-2. **Check documentation** - Refer to docs/ folder for context
-3. **Understand existing patterns** - Follow established conventions in the codebase
+Read these only when the task needs them:
 
-### When Troubleshooting
-
-1. Check [docs/development.md](docs/development.md) debugging section
-2. Check [docs/maintenance.md](docs/maintenance.md) troubleshooting section
-3. Verify Node.js version: 22+
-4. Try `npm run clean` before rebuilding
-
-### Common Tasks
-
-**Adding a blog post:**
-1. Create `src/blog/YYYY/MM/post-name.md`
-2. Add required frontmatter (title, description, date)
-3. Optional: Set `draft: true` to hide from production
-4. Build and test with `npm start`
-
-**Modifying styles:**
-1. Check existing patterns in `src/assets/css/`
-2. Use CSS layers appropriately
-3. Test in both light and dark modes
-4. Ensure responsive design
-
-**Updating dependencies:**
-1. Read [docs/maintenance.md](docs/maintenance.md) dependency management section
-2. Check release notes for breaking changes
-3. Test locally before deploying
-4. Monitor first deployment
-
-**Creating/modifying web components:**
-1. Follow Lit patterns in `src/assets/js/components/`
-2. Remember components are SSR at build time
-3. Import in `app.js` or create new component file
-
-### Git Workflow
-
-- **Main branch:** Production (auto-deploys to Cloudflare)
-- **Commit prefixes:** `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
-- **Before committing:** Run `npm run lint` and `npm run format`
-
-### Testing Checklist
-
-Before suggesting changes are complete:
-
-- [ ] Test locally with `npm start`
-- [ ] Run production build: `npm run build`
-- [ ] Test production build: `npm run dev`
-- [ ] Run `npm run lint`
-- [ ] Verify search works (if content changed)
-- [ ] Check both light and dark modes
-- [ ] Test responsive design
-
-## Build Pipeline
-
-### Development
-- Incremental builds with hot reload
-- Drafts visible
-- Serves on `http://localhost:8080`
-
-### Production
-1. Eleventy processes templates → static HTML
-2. Lit components server-side rendered
-3. CSS minified via clean-css
-4. Images optimized
-5. PageFind generates search index
-6. Outputs to `public/`
-7. Deployed to Cloudflare Workers
-
-### Deployment
-- **Automatic:** Push to `main` branch
-- **Hourly:** Cron job refreshes external RSS feeds
-- **Manual:** GitHub Actions workflow dispatch
-- **Duration:** Typically 2-3 minutes
-
-## Performance Considerations
-
-- Static generation for instant loads
-- Minimal JavaScript (web components only)
-- CSS minification automatic
-- Images optimized via `@11ty/eleventy-img`
-- Client-side search (no backend)
-- Edge deployment via Cloudflare Workers
-
-## Project Philosophy
-
-1. **Performance** - Static generation, minimal JavaScript
-2. **Simplicity** - No complex frameworks or build tools
-3. **Standards** - Modern web platform features
-4. **Maintainability** - Clear structure, minimal dependencies
-5. **Accessibility** - Semantic HTML, keyboard navigation
-6. **Developer Experience** - Fast builds, hot reload, clear code
-
-## Important Notes
-
-- Node.js version: **22+** required
-- Build artifacts in `public/` are git-ignored
-- Search requires full build: `npm run build`
-- External links automatically open in new tabs
-- Feeds available at `/feed.rss`, `/feed.atom`, `/feed.json`
-- Dark mode uses system preference (no toggle)
-- TOC auto-generated from headings in post layout
-
-## When Things Break
-
-1. **Build failing:** Run `npm run clean`, then `npm run build`
-2. **Search not working:** Run `npm run build:index`
-3. **CSS not applying:** Check layer order, clear browser cache
-4. **Drafts not showing:** Only visible in dev mode (`npm start`)
-5. **Hot reload broken:** Ensure port 8080 is free, restart dev server
-
-## Additional Resources
-
-- [Eleventy Documentation](https://www.11ty.dev/docs/)
-- [Lit Documentation](https://lit.dev/docs/)
-- [PageFind Documentation](https://pagefind.app/docs/)
-- [Cloudflare Workers Documentation](https://developers.cloudflare.com/workers/)
+- [docs/architecture.md](docs/architecture.md) — how SSR, search, feeds, service worker, and import maps work
+- [docs/development.md](docs/development.md) — setup, content authoring, markdown features, styling
+- [docs/deployment.md](docs/deployment.md) — CI/CD pipeline, Cloudflare setup, rollback
+- [docs/maintenance.md](docs/maintenance.md) — dependency updates, troubleshooting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,12 @@ See [Development Guide](docs/development.md) for detailed development instructio
 # Start development server
 npm start
 
+# Run unit tests
+npm run test:unit
+
+# Run e2e tests (Playwright)
+npm test
+
 # Build production version
 npm run build
 
@@ -357,13 +363,15 @@ Continue with...
 **Before submitting a PR:**
 
 1. Test locally with `npm start`
-2. Build production version: `npm run build`
-3. Test production build: `npm run dev`
-4. Test in multiple browsers (Chrome, Firefox, Safari)
-5. Test responsive design (mobile, tablet, desktop)
-6. Test dark mode
-7. Verify search works (if applicable)
-8. Check browser console for errors
+2. Run unit tests: `npm run test:unit`
+3. Run e2e tests: `npm test` (CI runs both suites and blocks deploys on failure)
+4. Build production version: `npm run build`
+5. Test production build: `npm run dev`
+6. Test in multiple browsers (Chrome, Firefox, Safari)
+7. Test responsive design (mobile, tablet, desktop)
+8. Test dark mode
+9. Verify search works (if applicable)
+10. Check browser console for errors
 
 **For UI changes:**
 
@@ -418,7 +426,7 @@ PRs are reviewed for:
 
 - Code quality and style
 - Adherence to project conventions
-- Test coverage (manual testing)
+- Test coverage (unit + e2e tests, plus manual checks)
 - Documentation updates
 - Performance impact
 - Breaking changes

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Visit [http://localhost:8080](http://localhost:8080) after starting the developm
 - External feed aggregation
 - Automatic dark mode
 - Responsive design
-- Hourly automated builds
+- Daily automated builds
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,10 +10,13 @@ pob.dev is a statically-generated personal website and blog built with modern we
 
 ### Core Technologies
 
-- **[Eleventy (11ty) 3.1.2](https://www.11ty.dev/)** - Static site generator that processes templates and content
-- **[Lit 3.3.1](https://lit.dev/)** - Web Components library with server-side rendering support
-- **[PageFind 1.4.0](https://pagefind.app/)** - Static search index generation for client-side search
+Current versions live in [package.json](../package.json).
+
+- **[Eleventy (11ty)](https://www.11ty.dev/)** - Static site generator that processes templates and content
+- **[Lit](https://lit.dev/)** - Web Components library with server-side rendering support
+- **[PageFind](https://pagefind.app/)** - Static search index generation for client-side search
 - **[Cloudflare Workers](https://workers.cloudflare.com/)** - Edge computing platform for hosting
+- **[Playwright](https://playwright.dev/)** - End-to-end browser testing
 
 ### Supporting Libraries
 
@@ -21,7 +24,7 @@ pob.dev is a statically-generated personal website and blog built with modern we
 - **clean-css** - CSS minification and optimization
 - **rss-parser** - RSS feed aggregation from external sources
 - **temporal-polyfill** - Temporal API polyfill for date/duration handling
-- **@11ty/eleventy-img 6.0.4** - Image optimization pipeline
+- **@11ty/eleventy-img** - Image optimization pipeline
 - **@11ty/eleventy-plugin-rss** - RSS/Atom/JSON feed generation
 - **linkedom** - Lightweight DOM implementation for SSR
 - **slugify** - URL-friendly slug generation
@@ -49,6 +52,7 @@ pob.dev/
 │   │   │   └── components/       # Component styles (post-list)
 │   │   └── js/components/        # Lit web components
 │   │       ├── app.js            # Main app shell
+│   │       ├── demo.js           # Live code demo component
 │   │       ├── note.js           # Note component
 │   │       └── tile.js           # Tile/card component
 │   ├── blog/                     # Blog posts
@@ -72,11 +76,16 @@ pob.dev/
 │   ├── feeds.js                  # RSS/Atom/JSON feed generation
 │   ├── feed-aggregator.js        # External feed aggregation
 │   ├── json-html.js              # JSON sanitization filter
+│   ├── syntax-highlight.js       # Per-page syntax highlighting
 │   └── table-of-contents.js      # Auto-generated table of contents
+├── tests/
+│   ├── unit/                     # Node test runner tests for 11ty/ plugins
+│   └── e2e/                      # Playwright browser tests
 ├── .github/workflows/
-│   └── deploy.yml                # CI/CD pipeline
+│   └── ci.yml                    # CI/CD pipeline (build, test, deploy)
 ├── public/                       # Build output (git-ignored)
 ├── eleventy.config.js            # Main Eleventy configuration
+├── playwright.config.js          # Playwright e2e test configuration
 ├── feeds.json                    # External feed sources
 ├── wrangler.jsonc                # Cloudflare Workers config
 └── package.json                  # Dependencies and scripts
@@ -107,7 +116,7 @@ pob.dev/
 - Configured via [feeds.json](../feeds.json)
 - Optional date filtering using Temporal duration strings (e.g., `P90D` for 90 days, `P1Y6M` for 1.5 years)
 - Automatically watches feed configuration file for changes in development mode
-- Refreshed hourly via automated builds
+- Refreshed daily via automated builds
 - See [11ty/feed-aggregator.js](../11ty/feed-aggregator.js)
 
 ### User Experience
@@ -214,7 +223,7 @@ The site uses an import map system for managing external dependencies like Lit, 
 
 **How it works:**
 - The `externals.js` plugin reads package versions from `node_modules`
-- Generates versioned paths for cache busting (e.g., `/assets/external/lit-3.3.1/`)
+- Generates versioned paths for cache busting (e.g., `/assets/external/lit-{version}/`)
 - Creates an import map that the browser uses to resolve bare module specifiers
 - Dependencies are copied to the output directory with version-stamped paths
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,8 +7,10 @@ This guide covers how pob.dev is deployed and how to set up your own deployment.
 pob.dev is deployed to **Cloudflare Workers** with automatic deployments triggered by:
 
 1. **Pushes to `main` branch** - Production deployments
-2. **Hourly cron schedule** - Refreshes external RSS feeds
+2. **Daily cron schedule** (midnight UTC) - Refreshes external RSS feeds
 3. **Manual workflow dispatch** - On-demand deployments
+
+Pull requests run the same build and test jobs but do not deploy.
 
 ## Platform: Cloudflare Workers
 
@@ -38,7 +40,7 @@ pob.dev is deployed to **Cloudflare Workers** with automatic deployments trigger
 
 ### GitHub Actions Workflow
 
-**File:** [.github/workflows/deploy.yml](../.github/workflows/deploy.yml)
+**File:** [.github/workflows/ci.yml](../.github/workflows/ci.yml)
 
 **Triggers:**
 
@@ -47,24 +49,24 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
-    - cron: '0 * * * *'  # Every hour at :00
+    - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:     # Manual trigger
 ```
 
-**Workflow Steps:**
+**Jobs** (all use Node.js 22):
 
-1. **Checkout repository** - Clones the repo
-2. **Setup Node.js** - Installs Node.js 24
-3. **Install dependencies** - Runs `npm ci`
-4. **Build site** - Runs `npm run build`
-5. **Publish to Cloudflare** - Deploys via Wrangler
+1. **Build** - `npm ci` + `npm run build`
+2. **Unit Tests** - `npm run test:unit`
+3. **E2E Tests** - Playwright tests via `npm test` (report uploaded as an artifact)
+4. **Deploy** - Runs only on `main`, only after the three jobs above pass; deploys via `cloudflare/wrangler-action`
 
-**Duration:** Typically 2-3 minutes
+### Why Daily Builds?
 
-### Why Hourly Builds?
-
-The hourly cron schedule refreshes the "Reading" page with the latest items from external RSS feeds. This keeps aggregated content current without requiring manual rebuilds.
+The daily cron schedule refreshes the "Reading" page with the latest items from external RSS feeds. This keeps aggregated content current without requiring manual rebuilds.
 
 ## Prerequisites for Deployment
 
@@ -247,7 +249,7 @@ export default {
 Add a status badge to show build status:
 
 ```markdown
-![Deploy Status](https://github.com/p-ob/pob.dev/actions/workflows/deploy.yml/badge.svg)
+![Deploy Status](https://github.com/p-ob/pob.dev/actions/workflows/ci.yml/badge.svg)
 ```
 
 ### Cloudflare Dashboard
@@ -310,15 +312,18 @@ git checkout main
 **Common issues:**
 
 - **Build errors** - Fix syntax errors, missing dependencies
+- **Test failures** - The deploy job only runs after unit and e2e tests pass; check test job logs
 - **Missing secrets** - Verify `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
-- **Node version mismatch** - Ensure Node 24+ in workflow
+- **Node version mismatch** - Ensure Node 22+ in workflow
 
 **Fix and retry:**
 
 ```bash
-git commit --amend
-git push --force origin main
+git commit -m "fix: resolve deployment issue"
+git push origin main
 ```
+
+(Avoid force-pushing to `main`; a new commit re-triggers the pipeline just as well.)
 
 ### Site Not Updating
 
@@ -395,6 +400,8 @@ Should contain:
 Before deploying major changes:
 
 - [ ] Test locally with `npm start`
+- [ ] Run unit tests: `npm run test:unit`
+- [ ] Run e2e tests: `npm test`
 - [ ] Run production build: `npm run build`
 - [ ] Test production build locally: `npm run dev`
 - [ ] Lint code: `npm run lint`
@@ -451,7 +458,7 @@ For a personal blog with moderate traffic, the free tier should be sufficient.
 
 - Upgrade to paid plan ($5/month for 10M requests)
 - Optimize build frequency
-- Consider reducing hourly cron to less frequent
+- Consider reducing the daily cron to less frequent
 
 ## Alternative Deployment Options
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ This guide will help you set up and develop on pob.dev locally.
 
 ## Prerequisites
 
-- **Node.js** - Version 22 or higher (24 recommended for CI parity)
+- **Node.js** - Version 22 or higher (CI uses 22)
 - **npm** - Comes with Node.js
 - **Git** - For version control
 
@@ -600,7 +600,7 @@ Feeds are fetched at build time and cached in the static output.
 **Build failing**
 - Run `npm run clean` to clear build artifacts
 - Delete `node_modules/` and run `npm ci`
-- Check Node.js version: `node --version` (should be 22+, 24 recommended)
+- Check Node.js version: `node --version` (should be 22+)
 
 ### Verbose Output
 
@@ -683,10 +683,22 @@ Before submitting changes:
 
 ### Automated Testing
 
-This project does not currently have automated tests. Changes are validated through:
-- Manual testing
-- Linting (`npm run lint`)
-- Production build success
+The project has two test suites, both run in CI on every push and pull request:
+
+**Unit tests** (`tests/unit/`) - Cover the custom Eleventy plugins in `11ty/` using the Node.js built-in test runner:
+
+```bash
+npm run test:unit
+```
+
+**End-to-end tests** (`tests/e2e/`) - Playwright browser tests covering the homepage, blog, feeds, reading page, dark mode, and page structure:
+
+```bash
+npm test        # Headless run (starts the dev server automatically)
+npm run test:ui # Interactive Playwright UI mode
+```
+
+When changing a plugin in `11ty/`, update its corresponding test in `tests/unit/`. When changing page structure or behavior, run `npm test` to catch regressions.
 
 ## Performance Considerations
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -17,7 +17,7 @@ Review outdated packages and plan updates.
 #### Review Automated Builds
 
 1. Go to **GitHub Actions**
-2. Check hourly cron builds are succeeding
+2. Check daily cron builds are succeeding
 3. Review any errors in recent workflows
 
 #### Monitor Site Performance
@@ -50,6 +50,7 @@ npm start
 **After updating:**
 - Test locally thoroughly
 - Run `npm run lint`
+- Run `npm run test:unit` and `npm test`
 - Commit changes with clear message
 - Monitor first deployment closely
 
@@ -95,12 +96,13 @@ npm outdated
 4. Update code if needed
 5. Deploy to production
 
-**Key dependencies to watch:**
+**Key dependencies to watch** (see [package.json](../package.json) for current versions):
 
-- **Eleventy** - Static site generator (currently 3.1.2)
-- **Lit** - Web components library (currently 3.3.1)
-- **PageFind** - Search functionality (currently 1.4.0)
-- **Wrangler** - Cloudflare deployment (currently 4.53.0)
+- **Eleventy** - Static site generator
+- **Lit** - Web components library
+- **PageFind** - Search functionality
+- **Wrangler** - Cloudflare deployment
+- **Playwright** - E2E testing (keep in sync with the container image tag in [ci.yml](../.github/workflows/ci.yml))
 
 #### Security Audit
 
@@ -130,12 +132,12 @@ Check if Node.js has new LTS versions:
 node --version
 ```
 
-Current requirement: **Node.js 22+** (CI uses Node.js 24)
+Current requirement: **Node.js 22+** (CI uses Node.js 22)
 
 **Update if needed:**
 
 1. Update [package.json](../package.json) engines field
-2. Update [.github/workflows/deploy.yml](../.github/workflows/deploy.yml) node-version
+2. Update [.github/workflows/ci.yml](../.github/workflows/ci.yml) node-version (all jobs)
 3. Test locally with new version
 4. Deploy and monitor
 
@@ -471,7 +473,7 @@ git clone https://github.com/p-ob/pob.dev.git backup-$(date +%Y%m%d)
 - `wrangler.jsonc`
 - `feeds.json`
 - `package.json`
-- `.github/workflows/deploy.yml`
+- `.github/workflows/ci.yml`
 - All files in `src/_data/`
 
 **These are backed up in Git** - no additional action needed.
@@ -616,7 +618,7 @@ git filter-branch --tree-filter 'rm -f path/to/large/file' HEAD
 1. **Update local Node.js**
 
 ```bash
-# Using nvm (recommended)
+# Using nvm (recommended) - replace 24 with the target version
 nvm install 24
 nvm use 24
 
@@ -638,10 +640,10 @@ Note: The `engines` field specifies minimum supported version. CI may use a newe
 
 3. **Update GitHub Actions**
 
-Edit [.github/workflows/deploy.yml](../.github/workflows/deploy.yml):
+Edit [.github/workflows/ci.yml](../.github/workflows/ci.yml) and update `node-version` in **every job** (build, unit-tests, e2e-tests, deploy):
 
 ```yaml
-- name: Set up Node.js
+- name: Setup Node
   uses: actions/setup-node@v4
   with:
     node-version: '24'
@@ -652,6 +654,8 @@ Edit [.github/workflows/deploy.yml](../.github/workflows/deploy.yml):
 ```bash
 npm ci
 npm run build
+npm run test:unit
+npm test
 npm start
 ```
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"plugins": [
+			{
+				"name": "ts-lit-plugin",
+				"rules": {
+					"no-invalid-css": "off"
+				}
+			}
+		]
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"wrangler": "^4.105.0"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=24"
 			}
 		},
 		"node_modules/@11ty/dependency-tree": {
@@ -999,9 +999,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1019,9 +1016,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1153,9 +1147,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1179,9 +1170,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1741,9 +1729,9 @@
 			}
 		},
 		"node_modules/anymatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1844,9 +1832,9 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2462,9 +2450,9 @@
 			"license": "MIT"
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2553,9 +2541,9 @@
 			}
 		},
 		"node_modules/gray-matter/node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2775,10 +2763,20 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -3145,9 +3143,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -3165,9 +3160,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -3185,9 +3177,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -3205,9 +3194,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -3225,9 +3211,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -3245,9 +3228,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -3265,9 +3245,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3291,9 +3268,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3317,9 +3291,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3343,9 +3314,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3369,9 +3337,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3395,9 +3360,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4078,9 +4040,9 @@
 			}
 		},
 		"node_modules/readdirp/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/p-ob/pob.dev/"
 	},
 	"engines": {
-		"node": ">=22"
+		"node": ">=24"
 	},
 	"devDependencies": {
 		"@11ty/eleventy": "^3.1.6",

--- a/src/assets/js/components/app.js
+++ b/src/assets/js/components/app.js
@@ -44,6 +44,8 @@ export class AppElement extends LitElement {
 		};
 	}
 
+	#mobileBreakpoint;
+
 	constructor() {
 		super();
 		this.currentYear = new Date().getFullYear();
@@ -52,8 +54,8 @@ export class AppElement extends LitElement {
 
 	#openMobileNav() {
 		const dialog = this.shadowRoot.querySelector("#mobile-nav-dialog");
-		dialog?.showModal();
 		document.body.style.overflow = "hidden";
+		dialog?.showModal();
 	}
 
 	#closeMobileNav() {
@@ -65,7 +67,19 @@ export class AppElement extends LitElement {
 		document.body.style.overflow = "";
 	}
 
+	// Sets the scroll lock when a `show-modal` command is invoked natively; the
+	// browser runs its default action (opening the dialog) after this fires.
+	#onDialogCommand(event) {
+		if (event.command === "show-modal") {
+			document.body.style.overflow = "hidden";
+		}
+	}
+
 	#handleDialogClick(event) {
+		// `closedby="any"` handles light-dismiss natively where supported.
+		if ("closedBy" in HTMLDialogElement.prototype) {
+			return;
+		}
 		const dialog = event.target;
 		const rect = dialog.getBoundingClientRect();
 		const isInDialog =
@@ -80,11 +94,40 @@ export class AppElement extends LitElement {
 
 	connectedCallback() {
 		super.connectedCallback();
-		window.addEventListener("resize", this.#handleResize.bind(this));
+		this.#mobileBreakpoint = window.matchMedia("(width <= 768px)");
+		this.#mobileBreakpoint.addEventListener("change", this.#handleBreakpointChange);
+		if (!("commandForElement" in HTMLButtonElement.prototype)) {
+			this.#installCommandFallback();
+		}
 	}
 
-	#handleResize() {
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.#mobileBreakpoint?.removeEventListener("change", this.#handleBreakpointChange);
+	}
+
+	#handleBreakpointChange = () => {
 		this.#closeMobileNav();
+	};
+
+	// Fallback for browsers without the Invoker Commands API (e.g. Safari < 26.2):
+	// the `command`/`commandfor` attributes on the nav buttons are otherwise inert.
+	#installCommandFallback() {
+		this.shadowRoot.addEventListener("click", (event) => {
+			const invoker = event.composedPath().find((el) => el instanceof HTMLElement && el.hasAttribute("commandfor"));
+			if (!invoker) {
+				return;
+			}
+			const target = this.shadowRoot.getElementById(invoker.getAttribute("commandfor"));
+			if (!(target instanceof HTMLDialogElement)) {
+				return;
+			}
+			if (invoker.getAttribute("command") === "show-modal") {
+				this.#openMobileNav();
+			} else if (invoker.getAttribute("command") === "close") {
+				this.#closeMobileNav();
+			}
+		});
 	}
 
 	#renderNavItems() {
@@ -106,7 +149,13 @@ export class AppElement extends LitElement {
 		return html` <div class="site-root">
 			<header>
 				<!-- Hamburger menu button (mobile only) -->
-				<button type="button" class="hamburger-menu" @click="${this.#openMobileNav}" aria-label="Open menu">
+				<button
+					type="button"
+					class="hamburger-menu"
+					command="show-modal"
+					commandfor="mobile-nav-dialog"
+					aria-label="Open menu"
+				>
 					${hamburgerIcon}
 				</button>
 
@@ -119,9 +168,23 @@ export class AppElement extends LitElement {
 			</header>
 
 			<!-- Mobile navigation dialog -->
-			<dialog id="mobile-nav-dialog" @click="${this.#handleDialogClick}" @close="${this.#onDialogClose}">
+			<dialog
+				id="mobile-nav-dialog"
+				closedby="any"
+				@command="${this.#onDialogCommand}"
+				@click="${this.#handleDialogClick}"
+				@close="${this.#onDialogClose}"
+			>
 				<div class="mobile-nav-content">
-					<button type="button" class="close-button" @click="${this.#closeMobileNav}" aria-label="Close menu">×</button>
+					<button
+						type="button"
+						class="close-button"
+						command="close"
+						commandfor="mobile-nav-dialog"
+						aria-label="Close menu"
+					>
+						×
+					</button>
 					<nav class="mobile-nav">
 						<div class="mobile-nav-main">${this.#renderNavItems()} ${this.#renderContactButton()}</div>
 						<div class="mobile-nav-footer">


### PR DESCRIPTION
## Summary
- Modernizes the mobile nav dialog in `app.js`: native `closedby=any` light-dismiss (with fallback), Invoker Commands API for open/close (with fallback), and `matchMedia` instead of a raw `resize` listener
- Refreshes docs (`CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/*.md`) to reflect the renamed `ci.yml` workflow, added unit/e2e test suites, and daily (was hourly) feed-refresh cron
- Bumps minimum Node engine to 24
- Adds local dev tooling config: Claude Code plugin/MCP settings (`.claude/settings.json`, `.mcp.json`), and a `jsconfig.json` disabling a noisy lit-plugin CSS rule

## Test plan
- [x] `npm run build:11ty` / `npm run build:index` succeed
- [x] `npm run lint` and `npm run test:unit` pass
- [x] Manually verified mobile nav in a live browser via Playwright MCP: open/close via hamburger and close button, breakpoint-crossing auto-close, scroll-lock set/released correctly, no console errors
- [ ] Fallback paths (pre-Invoker-Commands / pre-closedby browsers) not verified - no such browser available in this environment

Generated with Claude Code