### PR TITLE
fix: prevent ghost mobile nav dialog on narrow viewports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ pob.dev is a statically generated personal blog: Eleventy (templates/content) + 
 1. Read a file before editing it. Follow the patterns already in the file you are changing.
 2. Indent with tabs (width 2). Always use braces, even for single-line `if` statements. Prettier enforces formatting — run `npm run format` after editing and `npm run lint` before committing.
 3. Never edit anything in `public/` — it is generated build output and git-ignored.
-4. Pushing to `main` deploys to production via GitHub Actions, so verify changes before committing.
+4. Pushing to `main` deploys to production via GitHub Actions, so verify changes before committing. Never push directly to `main` — always work on a branch and open a pull request.
 5. Use commit prefixes: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`.
 6. When you change or add a custom plugin in `11ty/`, update or add its unit test in `tests/unit/`.
 7. Do not add bundlers, frameworks, or new runtime dependencies without being asked. This site deliberately uses plain web platform features (ES modules, import maps, CSS layers).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,15 +108,17 @@ Add secrets to your GitHub repository:
 
 ### 1. Automatic Deployment (Recommended)
 
-**Push to main branch:**
+**Never push directly to `main`.** Work on a branch and open a pull request:
 
 ```bash
+git checkout -b fix/my-change
 git add .
 git commit -m "feat: new feature"
-git push origin main
+git push origin fix/my-change
+gh pr create
 ```
 
-GitHub Actions automatically:
+Pull requests run the build and test jobs but do not deploy. Once the PR is reviewed and merged into `main`, GitHub Actions automatically:
 - Builds the site
 - Deploys to Cloudflare Workers
 - Makes it live at your domain
@@ -320,10 +322,10 @@ git checkout main
 
 ```bash
 git commit -m "fix: resolve deployment issue"
-git push origin main
+git push origin fix/my-branch
 ```
 
-(Avoid force-pushing to `main`; a new commit re-triggers the pipeline just as well.)
+Push a new commit to the open PR's branch; once merged to `main` it re-triggers the pipeline. (Avoid force-pushing to `main`.)
 
 ### Site Not Updating
 
@@ -412,7 +414,8 @@ Before deploying major changes:
 - [ ] Check external links
 - [ ] Review console for errors
 - [ ] Commit with clear message
-- [ ] Push to `main` branch
+- [ ] Push branch and open a pull request against `main`
+- [ ] Merge the pull request once checks pass and it's reviewed
 - [ ] Monitor GitHub Actions
 - [ ] Verify deployment on live site
 - [ ] Test live site functionality

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -42,8 +42,9 @@
 			import('syntax-highlight-element');
 			{% endif %}
 
-			// Register service worker for offline support
-			if ('serviceWorker' in navigator) {
+			// Register service worker for offline support (production only, so local dev
+			// never serves stale cached assets via stale-while-revalidate)
+			if ('serviceWorker' in navigator && location.origin === '{{ metadata.host }}') {
 				navigator.serviceWorker.register('/sw.js');
 			}
     </script>

--- a/src/assets/js/components/app.js
+++ b/src/assets/js/components/app.js
@@ -587,8 +587,8 @@ export class AppElement extends LitElement {
 				display: none;
 			}
 
-			/* Show mobile dialog on mobile */
-			#mobile-nav-dialog {
+			/* Show mobile dialog on mobile, but only once opened */
+			#mobile-nav-dialog[open] {
 				display: block;
 			}
 


### PR DESCRIPTION
## Summary
- Fix `#mobile-nav-dialog` rendering (as an in-flow, absolutely-positioned box overlapping page content) even while closed on viewports ≤768px, by scoping the mobile `display: block` rule to `[open]`.
- Stop registering the service worker outside production (`location.origin` check against `metadata.host`), so its stale-while-revalidate caching for `/assets/` can't mask JS/CSS changes during local development.
- Update `CLAUDE.md` and `docs/deployment.md` to require a branch + pull request instead of documenting/permitting direct pushes to `main`.

## Test plan
- [x] `npm run lint`
- [x] `npm run test:unit`
- [x] `npm run build:11ty` succeeds
- [x] Verified in a fresh browser context at 375px and 611px viewports: no ghost nav on load, dialog opens/closes correctly via the hamburger button
- [ ] Reviewer: confirm on pob.dev after merge (existing service worker on repeat visitors may need a reload or two to pick up the new cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)