### PR TITLE
Migrate search to Pagefind Component UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -55,7 +55,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.49.1-jammy
+      image: mcr.microsoft.com/playwright:v1.61.1-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Dependencies

--- a/src/search.njk
+++ b/src/search.njk
@@ -6,130 +6,52 @@ excludeFromSearch: true
 
 <h1>Search</h1>
 
-<div id="search"></div>
-<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
-<style>
-	/* PageFind theme customization */
-	:root {
-		--pagefind-ui-scale: 1;
-		--pagefind-ui-primary: hsl(220, 60%, 50%);
-		--pagefind-ui-text: var(--font-color);
-		--pagefind-ui-background: var(--page-background-color);
-		--pagefind-ui-border: color-mix(in srgb, var(--font-color) 20%, transparent);
-		--pagefind-ui-tag: color-mix(in srgb, var(--page-background-color), gray 20%);
-		--pagefind-ui-border-radius: 4px;
-		--pagefind-ui-font: inherit;
-	}
+<pagefind-config excerpt-length="20"></pagefind-config>
+<pagefind-input autofocus></pagefind-input>
+<pagefind-summary></pagefind-summary>
+<pagefind-results></pagefind-results>
 
-	/* Better highlight styling */
-	.pagefind-ui mark {
-		background-color: hsl(50, 100%, 70%);
-		color: hsl(0, 0%, 10%);
-		padding: 0.1em 0.2em;
-		border-radius: 2px;
+<link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+<style>
+	:root {
+		--pf-text: var(--font-color);
+		--pf-background: var(--page-background-color);
+		--pf-mark: var(--font-color);
+		--pf-border-radius: 4px;
+		--pf-font: inherit;
 	}
 
 	@media (prefers-color-scheme: dark) {
 		:root {
-			--pagefind-ui-primary: hsl(220, 70%, 65%);
+			--pf-border: #333;
+			--pf-border-focus: #555;
+			--pf-hover: #252525;
+			--pf-skeleton: #2a2a2a;
+			--pf-skeleton-shine: #333;
+			--pf-outline-focus: #58a6ff;
 		}
-
-		.pagefind-ui mark {
-			background-color: hsl(50, 80%, 40%);
-			color: hsl(0, 0%, 95%);
-		}
-	}
-
-	/* Keyboard navigation focus styles - only show outline on result container */
-	.pagefind-ui__result:focus-within {
-		outline: 2px solid var(--pagefind-ui-primary);
-		outline-offset: 4px;
-		border-radius: 4px;
-	}
-
-	.pagefind-ui__result-link:focus {
-		outline: none;
-	}
-
-	/* Improve result spacing */
-	.pagefind-ui__result-title {
-		margin-bottom: 0.25em;
-	}
-
-	.pagefind-ui__result-excerpt {
-		line-height: 1.5;
-		color: color-mix(in srgb, var(--font-color) 80%, transparent);
-	}
-
-	/* Search input improvements */
-	.pagefind-ui__search-input:focus {
-		outline: 2px solid var(--pagefind-ui-primary);
-		outline-offset: 2px;
-		border-color: var(--pagefind-ui-primary);
 	}
 </style>
-<script src="/pagefind/pagefind-ui.js"></script>
+<script src="/pagefind/pagefind-component-ui.js" type="module"></script>
 <script type="module">
-	const search = new PagefindUI({
-		element: "#search",
-		showSubResults: true,
-		showImages: false,
-		excerptLength: 20,
-		autofocus: true,
-		ranking: {
-			pageLength: 0.5,
-			termFrequency: 1.0,
-			termSimilarity: 1.2,
-		},
-	});
+	const { getInstanceManager } = window.PagefindComponents;
+	const instance = getInstanceManager().getInstance("default");
 
 	// Load initial query from URL
 	const params = new URLSearchParams(window.location.search);
 	const initialQuery = params.get("q");
 	if (initialQuery) {
-		search.triggerSearch(initialQuery);
+		instance.triggerSearch(initialQuery);
 	}
 
-	// Update URL when search input changes
-	const searchInput = document.querySelector(".pagefind-ui__search-input");
-	searchInput?.addEventListener("input", (e) => {
-		const query = e.target.value;
+	// Keep URL in sync with the search term
+	instance.on("search", (term) => {
 		const url = new URL(window.location);
-		if (query) {
-			url.searchParams.set("q", query);
+		if (term) {
+			url.searchParams.set("q", term);
 		} else {
 			url.searchParams.delete("q");
 		}
 		history.replaceState(null, "", url);
-	});
-
-	// Keyboard navigation for search results
-	document.addEventListener("keydown", (e) => {
-		const results = document.querySelectorAll(".pagefind-ui__result-link");
-		if (results.length === 0) {
-			return;
-		}
-
-		const active = document.activeElement;
-		const searchInput = document.querySelector(".pagefind-ui__search-input");
-		let currentIndex = Array.from(results).indexOf(active);
-
-		if (e.key === "ArrowDown") {
-			e.preventDefault();
-			if (active === searchInput || currentIndex === -1) {
-				results[0]?.focus();
-			} else if (currentIndex < results.length - 1) {
-				results[currentIndex + 1]?.focus();
-			}
-		} else if (e.key === "ArrowUp") {
-			e.preventDefault();
-			if (currentIndex > 0) {
-				results[currentIndex - 1]?.focus();
-			} else if (currentIndex === 0) {
-				searchInput?.focus();
-			}
-		} else if (e.key === "Escape") {
-			searchInput?.focus();
-		}
 	});
 </script>


### PR DESCRIPTION
## Summary
- Migrates `src/search.njk` from Pagefind's Default UI (`pagefind-ui.js`) to the new Component UI (`pagefind-input`/`pagefind-results`/`pagefind-summary`), the pattern Pagefind 1.5+ recommends for new integrations. Keyboard navigation is now built into the components (previously hand-rolled); the `?q=` URL sync is preserved via the instance's `triggerSearch()`/`on("search")` API. Theming uses the new `--pf-*` custom properties, tied to the site's existing light/dark tokens.
- Bumps CI's Node version (22→24) and Playwright container image (v1.49.1→v1.61.1) to match `package.json`'s `engines` field and the already-bumped `@playwright/test` devDependency.

## Test plan
- [x] `npm run lint` and `npm run test:unit` pass
- [x] `npm run build` succeeds with no Pagefind "Default UI" warning
- [x] Verified live with Playwright: typing a query returns highlighted results/sub-results and a results-count summary; `?q=` pre-fills and runs a search on load; typing updates the URL
- [x] Checked light mode, dark mode, and mobile viewport rendering
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)