### PR TITLE
feat: add Open Graph, Twitter Card, and Person/WebSite structured data

### DIFF
--- a/src/_data/metadata.js
+++ b/src/_data/metadata.js
@@ -12,6 +12,8 @@ try {
 export default {
 	currentYear: now.getFullYear(),
 	host: "https://pob.dev",
+	description:
+		"Personal site of Patrick O'Brien, a software engineer and engineering manager writing about the web ecosystem and engineering leadership.",
 	buildDate: now.toISOString(),
 	commitSha,
 };

--- a/src/_includes/layouts/partials/_head.njk
+++ b/src/_includes/layouts/partials/_head.njk
@@ -13,7 +13,7 @@
 			{{ author.name }}
 		{% endif %}
 	</title>
-	<meta name="description" content="{{ description }}">
+	<meta name="description" content="{{ description or metadata.description }}">
 	<meta name="generator" content="{{ eleventy.generator }}">
 	<meta name="robots" content="noai, noimageai">
 	<meta name="tdm-reservation" content="1">
@@ -22,13 +22,46 @@
 	<link rel="alternate" type="application/rss+xml" title="{{ author.name }} RSS Feed" href="/feed.rss">
 	<link rel="alternate" type="application/atom+xml" title="{{ author.name }} Atom Feed" href="/feed.atom">
 	<link rel="alternate" type="application/feed+json" title="{{ author.name }} JSON Feed" href="/feed.json">
+	<meta property="og:site_name" content="{{ author.name }}">
+	<meta property="og:type" content="{% if pageType == 'article' %}article{% else %}website{% endif %}">
+	<meta property="og:title" content="{{ title or author.name }}">
+	<meta property="og:description" content="{{ description or metadata.description }}">
+	<meta property="og:url" content="{{ metadata.host }}{{ page.url }}">
+	<meta name="twitter:card" content="summary">
+	<meta name="twitter:title" content="{{ title or author.name }}">
+	<meta name="twitter:description" content="{{ description or metadata.description }}">
+	{% if pageType == 'article' %}
+	<meta property="article:published_time" content="{{ page.date | machineDate }}">
+	{%- if updatedDate %}
+	<meta property="article:modified_time" content="{{ updatedDate | machineDate }}">
+	{%- endif %}
+	{% endif %}
+	<script type="application/ld+json">
+	{
+		"@context": "https://schema.org",
+		"@type": "WebSite",
+		"name": "{{ author.name | safe }}",
+		"description": "{{ metadata.description | safe }}",
+		"url": "{{ metadata.host }}",
+		"author": {
+			"@type": "Person",
+			"name": "{{ author.name | safe }}",
+			"url": "{{ metadata.host }}",
+			"email": "{{ author.email }}",
+			"sameAs": [
+				"{{ author.social.github }}",
+				"{{ author.social.bluesky }}"
+			]
+		}
+	}
+	</script>
 	{% if pageType == 'article' %}
 	<script type="application/ld+json">
 	{
 		"@context": "https://schema.org",
 		"@type": "BlogPosting",
-		"headline": "{{ title }}",
-		"description": "{{ description }}",
+		"headline": "{{ title | safe }}",
+		"description": "{{ description | safe }}",
 		"datePublished": "{{ page.date | machineDate }}",
 		{%- if updatedDate %}
 		"dateModified": "{{ updatedDate | machineDate }}",
@@ -36,12 +69,12 @@
 		"url": "{{ metadata.host }}{{ page.url }}",
 		"author": {
 			"@type": "Person",
-			"name": "{{ author.name }}",
+			"name": "{{ author.name | safe }}",
 			"url": "{{ metadata.host }}"
 		},
 		"publisher": {
 			"@type": "Person",
-			"name": "{{ author.name }}",
+			"name": "{{ author.name | safe }}",
 			"url": "{{ metadata.host }}"
 		},
 		"mainEntityOfPage": {

--- a/src/about.md
+++ b/src/about.md
@@ -1,5 +1,6 @@
 ---
 title: About
+description: Patrick O'Brien is a software engineer and engineering manager based in the Milwaukee area, writing about the web ecosystem and engineering leadership.
 noSidebar: true
 pageType: article
 ---

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,6 +1,7 @@
 ---
 noSidebar: true
 excludeFromSearch: true
+description: Software engineer and engineering manager writing about the web ecosystem, team collaboration, and the industry.
 ---
 
 <link rel="stylesheet" href="/assets/css/index.css">


### PR DESCRIPTION
Adds og:*/twitter:* meta tags and a WebSite+Person JSON-LD block so
shared links and search results carry a real title/description instead
of falling back to bare defaults. Fixes JSON-LD apostrophe escaping
that produced invalid entity-encoded text inside structured data
(pre-existing in the BlogPosting block). Also adds page descriptions
to the homepage and About page, and a site-wide description fallback
in metadata.js for pages that don't set their own.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MegQbUDVX4DN4AtNpK9uC7