### PR TITLE
feat: add devcontainer and fix Playwright MCP browser resolution

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+	"name": "pob.dev",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:24-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+	"forwardPorts": [8080, 8787],
+	"portsAttributes": {
+		"8080": {
+			"label": "Eleventy dev server (npm start)",
+			"onAutoForward": "notify"
+		},
+		"8787": {
+			"label": "Wrangler local preview (npm run dev)",
+			"onAutoForward": "silent"
+		}
+	},
+	"postCreateCommand": "bash .devcontainer/post-create.sh",
+	"remoteUser": "node",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"anthropic.claude-code",
+				"esbenp.prettier-vscode",
+				"runem.lit-plugin",
+				"ms-playwright.playwright",
+				"GitHub.vscode-pull-request-github",
+				"editorconfig.editorconfig"
+			],
+			"settings": {
+				"editor.defaultFormatter": "esbenp.prettier-vscode",
+				"editor.formatOnSave": true,
+				"editor.insertSpaces": false,
+				"editor.tabSize": 2
+			}
+		}
+	}
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Trusting workspace for git (bind-mounted volumes can be owned by a different uid)"
+git config --global --add safe.directory "${containerWorkspaceFolder:-$(pwd)}"
+
+echo "==> Installing npm dependencies (npm ci)"
+npm ci
+
+echo "==> Installing Playwright browser (chromium, with OS dependencies)"
+npx playwright install --with-deps chromium
+
+echo "==> Installing Chrome for Testing (used by the Playwright MCP server)"
+npx @playwright/mcp install-browser chrome-for-testing
+
+echo "==> Installing Claude Code CLI"
+npm install -g @anthropic-ai/claude-code
+
+if [ ! -f .env ] && [ -f .env.example ]; then
+	echo "==> Seeding .env from .env.example (fill in secrets before running npm run publish:standard)"
+	cp .env.example .env
+fi
+
+echo "==> Checking GitHub CLI auth status"
+gh auth status || echo "    Not logged in yet — run 'gh auth login' to enable 'gh' commands."
+
+echo "==> Done. Run 'npm start' to launch the dev server on http://localhost:8080"

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
 		"playwright": {
 			"type": "stdio",
 			"command": "npx",
-			"args": ["-y", "@playwright/mcp@latest"],
+			"args": ["-y", "@playwright/mcp@latest", "--browser=chromium"],
 			"env": {}
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds the devcontainer config (image, features, `post-create.sh` setup) that was staged but not yet committed.
- Fixes a gap found while doing an end-to-end validation of the new devcontainer: the Playwright MCP server (`@playwright/mcp`) defaults to the system `chrome` channel, which isn't installed in the container — only the plain Playwright-managed `chromium` build that `post-create.sh` already fetches for the e2e suite. Browser automation via MCP failed immediately on a fresh container with `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`.
- Points `.mcp.json` at `--browser=chromium` (uses Playwright's own downloaded "Chrome for Testing" build rather than requiring a system Chrome install) and pre-installs that build in `post-create.sh` so it's ready on first use instead of downloading ~300MB on first MCP call.

## Test plan
- [x] `npm run lint` and `npm run test:unit` (61/61 passing)
- [x] `npm start` — dev server builds and serves on :8080
- [x] Playwright MCP: navigated to homepage, clicked through to `/blog/`, captured snapshot/screenshot, no unexpected console errors
- [x] `git`/`gh` CLI sanity-checked (status, log, remote, push, `gh auth status`, `gh pr create`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)