### PR TITLE
chore: cut over to npm v12 (GA)

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 echo "==> Trusting workspace for git (bind-mounted volumes can be owned by a different uid)"
 git config --global --add safe.directory "${containerWorkspaceFolder:-$(pwd)}"
 
+echo "==> Updating npm to v12 (the base image's bundled npm lags behind package.json's engines requirement)"
+npm install -g npm@12
+
 echo "==> Installing npm dependencies (npm ci)"
 npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      - name: Update npm
+        # Node 24's bundled npm lags behind the required v12 (see package.json engines).
+        run: npm install -g npm@12
+
       - name: Install Dependencies
         run: npm ci
 
@@ -76,6 +80,10 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+
+      - name: Update npm
+        # Node 24's bundled npm lags behind the required v12 (see package.json engines).
+        run: npm install -g npm@12
 
       - name: Install Dependencies
         run: npm ci
@@ -108,6 +116,10 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+
+      - name: Update npm
+        # Node 24's bundled npm lags behind the required v12 (see package.json engines).
+        run: npm install -g npm@12
 
       - name: Install Dependencies
         run: npm ci
@@ -147,6 +159,10 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+
+      - name: Update npm
+        # Node 24's bundled npm lags behind the required v12 (see package.json engines).
+        run: npm install -g npm@12
 
       - name: Install Dependencies
         run: npm ci

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ on:
   workflow_dispatch:     # Manual trigger
 ```
 
-**Jobs** (all use Node.js 22):
+**Jobs** (all use Node.js 24 and update to npm 12 before installing dependencies):
 
 1. **Build** - `npm ci` + `npm run build`
 2. **Unit Tests** - `npm run test:unit`

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,8 +4,8 @@ This guide will help you set up and develop on pob.dev locally.
 
 ## Prerequisites
 
-- **Node.js** - Version 22 or higher (CI uses 22)
-- **npm** - Comes with Node.js
+- **Node.js** - Version 24.15.0 or higher (CI uses 24)
+- **npm** - Version 12.0.0 or higher (Node's bundled npm may lag behind; run `npm install -g npm@12` to update)
 - **Git** - For version control
 
 ## Initial Setup
@@ -610,7 +610,7 @@ Feeds are fetched at build time and cached in the static output.
 **Build failing**
 - Run `npm run clean` to clear build artifacts
 - Delete `node_modules/` and run `npm ci`
-- Check Node.js version: `node --version` (should be 22+)
+- Check Node.js version: `node --version` (should be 24.15.0+) and npm version: `npm --version` (should be 12+)
 
 ### Verbose Output
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -130,7 +130,7 @@ Given the frequency of malicious npm package publishes, this project layers on a
 
 - **Install cooldown** — [.npmrc](../.npmrc) sets `min-release-age=7`, so `npm install`/`npm update` refuses any package version published less than 7 days ago. Most compromised versions get pulled within hours of discovery, so this closes the window attackers rely on. `npm ci` ignores it (CI installs exactly what's pinned in `package-lock.json`), so it mostly matters when you're adding or bumping a dependency locally. If you genuinely need a brand-new release before it clears the cooldown, override once with `npm install pkg@version --min-release-age=0`.
 - **Registry signature verification** — CI runs `npm audit signatures` on every build, which verifies every package in the lock file against npm's registry-signing keys. Run it locally too after a big dependency bump. Note that this command *does* honor `min-release-age` (it re-resolves each locked package against the registry rather than just reading the lockfile), so the Build job in [ci.yml](../.github/workflows/ci.yml) sets `NPM_CONFIG_MIN_RELEASE_AGE=0` for the job — a pinned, already-reviewed lockfile has nothing left for the cooldown to protect against, and without the override the step fails (`ETARGET`) whenever a pinned dependency was published within the last week.
-- **Install script allowlist** — [package.json](../package.json) has a top-level `allowScripts` map naming the packages allowed to run install/postinstall scripts (currently `esbuild`, `fsevents`, `sharp`, `workerd` — all needed for native binaries used by Wrangler/Miniflare and Eleventy's image processing). This is prep for [npm v12's `allowScripts`-off-by-default change](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/): once a package's scripts aren't on the allowlist, npm silently skips them instead of running them. If a future dependency bump legitimately needs a new package's install script, npm will warn `N packages have install scripts not yet covered by allowScripts` — review the script with `npm view <pkg> scripts`, then approve it with `npm approve-scripts <pkg>` (add `--no-allow-scripts-pin` to allow by name rather than pinning to the exact version, so routine bumps don't need re-approval every time).
+- **Install script allowlist** — [package.json](../package.json) has a top-level `allowScripts` map naming the packages allowed to run install/postinstall scripts (currently `esbuild`, `fsevents`, `sharp`, `workerd` — all needed for native binaries used by Wrangler/Miniflare and Eleventy's image processing). This project requires [npm v12](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/), which turns `allowScripts` off by default: once a package's scripts aren't on the allowlist, npm silently skips them instead of running them. If a dependency bump legitimately needs a new package's install script, npm will warn `N packages have install scripts not yet covered by allowScripts` — review the script with `npm view <pkg> scripts`, then approve it with `npm approve-scripts <pkg>` (add `--no-allow-scripts-pin` to allow by name rather than pinning to the exact version, so routine bumps don't need re-approval every time).
 - **Pinned GitHub Actions** — every third-party Action in `.github/workflows/` is pinned to a commit SHA (not a mutable version tag) with a version comment, and Dependabot's `github-actions` ecosystem entry in [dependabot.yml](../.github/dependabot.yml) keeps those SHAs current. `step-security/harden-runner` runs first in every job in `egress-policy: audit` mode, logging any unexpected outbound network calls a compromised dependency's install script might make (check the job summary in the Actions run if you want to look for anomalies).
 - **Careful auto-merge** — [dependabot-auto-merge.yml](../.github/workflows/dependabot-auto-merge.yml) only auto-merges patch/minor Dependabot PRs; major version bumps (of npm packages or Action SHAs) require manual review before merging.
 
@@ -142,7 +142,7 @@ Check if Node.js has new LTS versions:
 node --version
 ```
 
-Current requirement: **Node.js 22+** (CI uses Node.js 22)
+Current requirement: **Node.js 24.15.0+** (CI uses Node.js 24) and **npm 12.0.0+** (CI and the dev container upgrade npm explicitly, since the Node base image's bundled npm lags behind)
 
 **Update if needed:**
 
@@ -640,7 +640,7 @@ node --version
 ```json
 {
   "engines": {
-    "node": ">=22"
+    "node": ">=24.15.0"
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
 				"wrangler": "^4.107.0"
 			},
 			"engines": {
-				"node": ">=24",
-				"npm": ">=11.16.0"
+				"node": ">=24.15.0",
+				"npm": ">=12.0.0"
 			}
 		},
 		"node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
 		"url": "https://github.com/p-ob/pob.dev/"
 	},
 	"engines": {
-		"node": ">=24",
-		"npm": ">=11.16.0"
+		"node": ">=24.15.0",
+		"npm": ">=12.0.0"
 	},
 	"devDependencies": {
 		"@11ty/eleventy": "^3.1.6",


### PR DESCRIPTION
npm v12 is now generally available and turns allowScripts off by
default. This repo already had the allowScripts allowlist prepped, so
the remaining work is making sure CI, the dev container, and the local
toolchain actually run npm 12 instead of the older npm still bundled
with Node 24:

- package.json/package-lock.json: require npm >=12.0.0 and node
  >=24.15.0 (npm 12's minimum for the Node 24 line)
- ci.yml: upgrade npm to v12 in every job right after Setup Node, since
  the runner's bundled npm lags behind
- devcontainer post-create.sh: same npm upgrade before `npm ci`
- docs: update stale Node 22 references to 24, note the npm 12
  requirement, and drop the "prep for a future change" framing now
  that v12 is out

Verified locally with npm 12.0.0: npm ci, npm run lint, npm run build,
and npm run test:unit all pass with no allowScripts warnings.