### PR TITLE
feat: enable smart typography for Markdown

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -198,6 +198,10 @@ export default async function (eleventyConfig) {
 
 	// additional config
 	eleventyConfig.amendLibrary("md", (mdLib) => {
+		// Enables smart typography: -- / --- become en/em dashes, straight quotes
+		// become curly quotes, (c)/(tm)/(r) become symbols, ... becomes an ellipsis.
+		mdLib.set({ typographer: true });
+
 		mdLib.use(markdownItFootnote);
 
 		// Add container support for note types

--- a/src/about.md
+++ b/src/about.md
@@ -19,7 +19,7 @@ If you, too, are in technology, follow along to read about my musings on many to
 
 ## Personal life
 
-As I mentioned earlier, I currently reside in the Milwaukee area. I'm a huge Tolkien nerd, collecting various editions of his works and trying to (re)read them when I can find the time. I'm also a father to a lovable oaf of a Bernese Mountain Dog (Pippin) -- I'm sure he'll make some cameos elsewhere in my site.
+As I mentioned earlier, I currently reside in the Milwaukee area. I'm a huge Tolkien nerd, collecting various editions of his works and trying to (re)read them when I can find the time. I'm also a father to a lovable oaf of a Bernese Mountain Dog (Pippin) --- I'm sure he'll make some cameos elsewhere in my site.
 
 When I'm not working, I'm usually playing some video game or another. My guilty pleasure is League of Legends, but I play all sorts, primarily sandbox/survival games.
 


### PR DESCRIPTION
Configures Markdown processing to automatically convert plain text sequences (e.g., `---` to em dashes, `"` to curly quotes, `(c)` to ©, `...` to ellipses). This improves the visual polish and readability of content.