### PR TITLE
feat: disable external RSS feed fetching by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,11 @@ jobs:
 
       - name: Rebuild Site
         run: npm run build
+        env:
+          # Production is the one build that should actually fetch the
+          # external RSS feeds for the Reading page; every other build in
+          # this workflow leaves external feed fetching off by default.
+          FETCH_EXTERNAL_FEEDS: true
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0

--- a/11ty/feed-aggregator.js
+++ b/11ty/feed-aggregator.js
@@ -45,8 +45,8 @@ export function FeedAggregatorPlugin(eleventyConfig, options = {}) {
 
   // Add global data for aggregated feeds
   eleventyConfig.addGlobalData("aggregatedFeeds", async () => {
-    if (process.env.SKIP_FEED_AGGREGATION) {
-      console.log("[FeedAggregator] SKIP_FEED_AGGREGATION is set; skipping external feed fetches");
+    if (!process.env.FETCH_EXTERNAL_FEEDS) {
+      console.log("[FeedAggregator] FETCH_EXTERNAL_FEEDS is not set; skipping external feed fetches");
       return [];
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,8 @@ pob.dev/
 - Configured via [feeds.json](../feeds.json)
 - Optional date filtering using Temporal duration strings (e.g., `P90D` for 90 days, `P1Y6M` for 1.5 years)
 - Automatically watches feed configuration file for changes in development mode
-- Refreshed daily via automated builds
+- Off by default: fetching only happens when `FETCH_EXTERNAL_FEEDS=true` is set (production deploys set this; set it locally when working on the Reading page)
+- Refreshed daily via automated production builds
 - See [11ty/feed-aggregator.js](../11ty/feed-aggregator.js)
 
 ### User Experience

--- a/docs/development.md
+++ b/docs/development.md
@@ -537,6 +537,12 @@ Components are server-side rendered at build time via `@lit-labs/eleventy-plugin
 
 ## Adding External Feeds
 
+External feed fetching is off by default (the Reading page renders with no aggregated items) so that ordinary builds and dev servers don't depend on network access to third-party feeds. To actually fetch feeds — e.g. while working on the Reading page — set `FETCH_EXTERNAL_FEEDS=true`:
+
+```bash
+FETCH_EXTERNAL_FEEDS=true npm start
+```
+
 To add RSS feeds to the "Reading" page:
 
 1. **Edit `feeds.json`**

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -355,7 +355,7 @@ npm run build
 3. Review build logs for fetch errors
 4. Consider feed might be temporarily down
 5. Add error handling in [11ty/feed-aggregator.js](../11ty/feed-aggregator.js)
-6. In a network-restricted environment (CI sandbox, offline dev), set `SKIP_FEED_AGGREGATION=true` to skip the fetches entirely — the Reading page just renders with no aggregated items
+6. External feed fetching is off by default — set `FETCH_EXTERNAL_FEEDS=true` to actually fetch feeds (e.g. when working on the Reading page). Without it, the Reading page just renders with no aggregated items
 
 ### Deployment Failures
 
@@ -398,7 +398,7 @@ git push origin main
 
 1. `npm start` already runs a Watch server; add `npm run build:11ty` alone for one-off rebuilds instead of the full `npm run build` when you don't need a fresh search index.
 
-2. If the build hangs or is slow on the external RSS fetches in [11ty/feed-aggregator.js](../11ty/feed-aggregator.js) (e.g. no network access, feeds blocked by a proxy), set `SKIP_FEED_AGGREGATION=true` to bypass them.
+2. External RSS fetches in [11ty/feed-aggregator.js](../11ty/feed-aggregator.js) are off by default, so they won't hang or slow down a normal build. If you've set `FETCH_EXTERNAL_FEEDS=true` to work on the Reading page and hit slow/blocked feeds, unset it to bypass them.
 
 3. Clean build artifacts:
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -23,8 +23,5 @@ export default defineConfig({
         reuseExistingServer: !process.env.CI,
         stdout: "ignore",
         stderr: "pipe",
-        // e2e specs already tolerate feeds being absent (see tests/e2e/reading.spec.js),
-        // so skip the external RSS fetches to avoid gating the whole suite behind them.
-        env: { ...process.env, SKIP_FEED_AGGREGATION: "true" },
     },
 });

--- a/tests/unit/feed-aggregator.test.js
+++ b/tests/unit/feed-aggregator.test.js
@@ -45,64 +45,7 @@ mock.module("rss-parser", {
 import { FeedAggregatorPlugin } from "../../11ty/feed-aggregator.js";
 
 describe("FeedAggregatorPlugin", () => {
-	it("should aggregate feeds and filter by duration", async () => {
-		mockShouldThrow = false;
-		const mockEleventy = new EleventyMock();
-
-		FeedAggregatorPlugin(mockEleventy, {
-			durationLimit: "P1Y", // 1 Year
-		});
-
-		// Get the global data function
-		const dataFn = mockEleventy.globalData.get("aggregatedFeeds");
-		assert.ok(dataFn);
-
-		// Execute the function
-		const results = await dataFn();
-
-		assert.strictEqual(results.length, 1, "Should filter out old and future posts");
-		assert.strictEqual(results[0].title, "Post 1");
-	});
-
-	it("should filter out future-dated posts", async () => {
-		mockShouldThrow = false;
-		const mockEleventy = new EleventyMock();
-
-		FeedAggregatorPlugin(mockEleventy, {});
-
-		// Emit event to clear cache
-		mockEleventy.emit("eleventy.beforeWatch", ["feeds.json"]);
-
-		// Get the global data function
-		const dataFn = mockEleventy.globalData.get("aggregatedFeeds");
-		assert.ok(dataFn);
-
-		// Execute the function
-		const results = await dataFn();
-
-		// Should include today's post and old post, but exclude the future post
-		assert.strictEqual(results.length, 2, "Should filter out only future posts");
-		assert.ok(!results.some((item) => item.title === "Future Post"), "Should not include future posts");
-		assert.ok(results.some((item) => item.title === "Post 1"), "Should include current post");
-		assert.ok(results.some((item) => item.title === "Old Post"), "Should include old posts when no duration limit");
-	});
-
-	it("should handle fetch errors gracefully", async () => {
-		mockShouldThrow = true;
-		const mockEleventy = new EleventyMock();
-		FeedAggregatorPlugin(mockEleventy, {});
-
-		// Emit event to clear cache (since the plugin caches the result in module scope)
-		mockEleventy.emit("eleventy.beforeWatch", ["feeds.json"]);
-
-		const dataFn = mockEleventy.globalData.get("aggregatedFeeds");
-		const results = await dataFn();
-
-		// Should return empty array on failure
-		assert.deepStrictEqual(results, []);
-	});
-
-	it("should skip fetching when SKIP_FEED_AGGREGATION is set", async () => {
+	it("should skip fetching by default (FETCH_EXTERNAL_FEEDS unset)", async () => {
 		mockShouldThrow = false;
 		parseURLCallCount = 0;
 		const mockEleventy = new EleventyMock();
@@ -111,15 +54,89 @@ describe("FeedAggregatorPlugin", () => {
 		// Emit event to clear cache (since the plugin caches the result in module scope)
 		mockEleventy.emit("eleventy.beforeWatch", ["feeds.json"]);
 
-		process.env.SKIP_FEED_AGGREGATION = "true";
+		delete process.env.FETCH_EXTERNAL_FEEDS;
+		const dataFn = mockEleventy.globalData.get("aggregatedFeeds");
+		const results = await dataFn();
+
+		assert.deepStrictEqual(results, []);
+		assert.strictEqual(parseURLCallCount, 0, "Should not fetch any feeds");
+	});
+
+	it("should aggregate feeds and filter by duration when enabled", async () => {
+		mockShouldThrow = false;
+		const mockEleventy = new EleventyMock();
+
+		FeedAggregatorPlugin(mockEleventy, {
+			durationLimit: "P1Y", // 1 Year
+		});
+
+		// Emit event to clear cache (since the plugin caches the result in module scope)
+		mockEleventy.emit("eleventy.beforeWatch", ["feeds.json"]);
+
+		process.env.FETCH_EXTERNAL_FEEDS = "true";
+		try {
+			// Get the global data function
+			const dataFn = mockEleventy.globalData.get("aggregatedFeeds");
+			assert.ok(dataFn);
+
+			// Execute the function
+			const results = await dataFn();
+
+			assert.strictEqual(results.length, 1, "Should filter out old and future posts");
+			assert.strictEqual(results[0].title, "Post 1");
+		} finally {
+			delete process.env.FETCH_EXTERNAL_FEEDS;
+		}
+	});
+
+	it("should filter out future-dated posts when enabled", async () => {
+		mockShouldThrow = false;
+		const mockEleventy = new EleventyMock();
+
+		FeedAggregatorPlugin(mockEleventy, {});
+
+		// Emit event to clear cache
+		mockEleventy.emit("eleventy.beforeWatch", ["feeds.json"]);
+
+		process.env.FETCH_EXTERNAL_FEEDS = "true";
+		try {
+			// Get the global data function
+			const dataFn = mockEleventy.globalData.get("aggregatedFeeds");
+			assert.ok(dataFn);
+
+			// Execute the function
+			const results = await dataFn();
+
+			// Should include today's post and old post, but exclude the future post
+			assert.strictEqual(results.length, 2, "Should filter out only future posts");
+			assert.ok(!results.some((item) => item.title === "Future Post"), "Should not include future posts");
+			assert.ok(results.some((item) => item.title === "Post 1"), "Should include current post");
+			assert.ok(
+				results.some((item) => item.title === "Old Post"),
+				"Should include old posts when no duration limit"
+			);
+		} finally {
+			delete process.env.FETCH_EXTERNAL_FEEDS;
+		}
+	});
+
+	it("should handle fetch errors gracefully when enabled", async () => {
+		mockShouldThrow = true;
+		const mockEleventy = new EleventyMock();
+		FeedAggregatorPlugin(mockEleventy, {});
+
+		// Emit event to clear cache (since the plugin caches the result in module scope)
+		mockEleventy.emit("eleventy.beforeWatch", ["feeds.json"]);
+
+		process.env.FETCH_EXTERNAL_FEEDS = "true";
 		try {
 			const dataFn = mockEleventy.globalData.get("aggregatedFeeds");
 			const results = await dataFn();
 
+			// Should return empty array on failure
 			assert.deepStrictEqual(results, []);
-			assert.strictEqual(parseURLCallCount, 0, "Should not fetch any feeds");
 		} finally {
-			delete process.env.SKIP_FEED_AGGREGATION;
+			delete process.env.FETCH_EXTERNAL_FEEDS;
 		}
 	});
 });


### PR DESCRIPTION
The Reading page's feed aggregator used to fetch external feeds on every
build unless SKIP_FEED_AGGREGATION was explicitly set, making local dev
and CI builds depend on third-party network access. Invert the flag to
FETCH_EXTERNAL_FEEDS, opt-in and off by default, and only enable it in
the production deploy build. Update docs and tests accordingly.