### PR TITLE
fix: bump brace-expansion to 1.1.16 to resolve high severity npm audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2271,9 +2271,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Summary
- The scheduled CI/CD Pipeline run was failing on the `npm audit --audit-level=high` step ([run](https://github.com/p-ob/pob.dev/actions/runs/29793104643)) due to [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (ReDoS) in `brace-expansion@1.1.15`
- This is a transitive dependency via `@11ty/eleventy` → `@11ty/recursive-copy` → `minimatch`
- Bumped `brace-expansion` to the patched `1.1.16` via `npm audit fix` (lockfile-only change, no `package.json` change needed)

## Test plan
- [x] `npm audit --audit-level=high` reports 0 vulnerabilities
- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (61/61)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GK7FFQxcoocbkG6kRBzE55)_