### PR TITLE
fix: suppress browser-added print header/footer on résumé

### DIFF
--- a/src/assets/css/resume-print.css
+++ b/src/assets/css/resume-print.css
@@ -8,13 +8,34 @@
 /*
  * A real @page margin applies to *every* printed page, so multi-page résumés
  * stay properly inset (a zero margin would jam page 2+ content against the paper
- * edge). The trade-off: browsers may draw their own headers/footers (URL, title,
- * date, page numbers) in this margin — that's the print dialog's "Headers and
- * footers" toggle, which is the user's to control; CSS can't force it off.
+ * edge). Browsers draw their own headers/footers (URL, title, date, page
+ * numbers) inside this margin unless the page claims it: declaring a page
+ * margin box — even an empty one — tells the browser to render that corner
+ * from CSS instead of its own default (CSS Paged Media Module Level 3).
+ * Supported in Chrome/Edge 131+ and Safari 18.2+; Firefox hasn't shipped
+ * margin boxes yet (Mozilla bug 1854974), so Firefox users still see the
+ * browser default there unless they toggle "Headers and footers" off
+ * themselves in the print dialog.
  */
 @page {
 	size: letter portrait;
 	margin: 0.6in;
+
+	@top-left {
+		content: "";
+	}
+
+	@top-right {
+		content: "";
+	}
+
+	@bottom-left {
+		content: "";
+	}
+
+	@bottom-right {
+		content: "";
+	}
 }
 
 html,


### PR DESCRIPTION
## Summary
- Declare empty `@page` margin boxes (`@top-left`, `@top-right`, `@bottom-left`, `@bottom-right`) in `src/assets/css/resume-print.css` so supporting browsers render those corners from CSS instead of drawing their own default print header/footer (URL, title, date, page count) there.
- Uses [CSS Paged Media Module Level 3](https://www.w3.org/TR/css-page-3/) margin boxes, shipped in Chrome/Edge 131+ and Safari 18.2+. Firefox hasn't implemented margin boxes yet (tracked in [Mozilla bug 1854974](https://bugzilla.mozilla.org/show_bug.cgi?id=1854974)), so it still falls back to its own default header/footer unless the user disables "Headers and footers" in the print dialog themselves.
- Updated the code comment above `@page` to reflect the new capability (previously said this couldn't be done from CSS at all).

## Test plan
- [x] `npm run format` / `npm run lint` — clean
- [x] `npm run test:unit` — 61/61 passing
- [x] `npm run build` — succeeds, verified compiled `public/assets/css/resume-print.css` contains the new margin-box rules unmodified
- [ ] Manual: print-preview `/resume/` in Chrome/Safari and confirm no browser URL/date/page-count chrome appears in the margins

---
_Generated by [Claude Code](https://claude.ai/code/session_0111K3Hm9ikN2fEhaBUV8mYR)_