### PR TITLE
fix: pin brace-expansion and undici overrides to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2318,9 +2318,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5112,9 +5112,9 @@
 			"license": "ISC"
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"@11ty/eleventy-img": {
 			"sharp": "^0.35.3"
 		},
-		"brace-expansion": "^5.0.8"
+		"brace-expansion": "^5.0.9",
+		"undici": "^7.29.0"
 	}
 }


### PR DESCRIPTION
The scheduled CI run failed npm audit --audit-level=high: brace-expansion
5.0.8 and undici <=7.28.0 (pulled in transitively via wrangler/miniflare)
both had newly disclosed high-severity advisories. Bump the existing
override to brace-expansion@5.0.9 and add an override pinning undici to
7.29.0, which patches the advisories in place without requiring a
breaking wrangler downgrade.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011EULtF6JKiCEtP6ttECFyr